### PR TITLE
Add missing imports to getting started documentation

### DIFF
--- a/packages/documentation/docs/args.md
+++ b/packages/documentation/docs/args.md
@@ -11,6 +11,7 @@ sidebar_label: Command line arguments
 To read the arguments passed in from command line, use the `this.argv` object provided by `yargs`.
 
 ```js
+const { task, logger } = require('just-task');
 task('pillageMeArgs', function() {
   logger.info('a bunch of aarrrrrrgs', this.argv);
 });

--- a/packages/documentation/docs/preset-jest.md
+++ b/packages/documentation/docs/preset-jest.md
@@ -8,6 +8,7 @@ Jest is one of the most popular testing libraries in the Javascript ecosystem. I
 
 ```tsx
 // just-task.js
+import { task } from 'just-task';
 import { jestTask } from 'just-task-preset';
 task('test', jestTask());
 ```
@@ -16,6 +17,7 @@ You can pass in a few options like any another preset tasks in the `just-task-pr
 
 ```tsx
 // just-task.js
+import { task } from 'just-task';
 import { jestTask } from 'just-task-preset';
 
 const options = {

--- a/packages/documentation/docs/preset-ts.md
+++ b/packages/documentation/docs/preset-ts.md
@@ -12,6 +12,7 @@ A list of available options are located at the [Typescript documentation site](h
 
 ```tsx
 // just-task.js
+import { task } from 'just-task';
 import { tscTask } from 'just-task-preset';
 task('ts', tscTask());
 ```
@@ -20,7 +21,7 @@ For variety, try having two kinds of output at the same time (built in parallel)
 
 ```tsx
 // just-task.js
-import { parallel } from 'just-task';
+import { task, parallel } from 'just-task';
 import { tscTask } from 'just-task-preset';
 task('ts:commonjs', tscTask({ module: 'commonjs' }));
 task('ts:esnext', tscTask({ module: 'esnext' }));

--- a/packages/documentation/docs/preset-tslint.md
+++ b/packages/documentation/docs/preset-tslint.md
@@ -8,6 +8,7 @@ Typescript is a very popular compiler. But as the amount of code grows, develope
 
 ```tsx
 // just-task.js
+import { task } from 'just-task';
 import { tslintTask } from 'just-task-preset';
 task('tslint', tslintTask());
 ```

--- a/packages/documentation/docs/presets.md
+++ b/packages/documentation/docs/presets.md
@@ -12,6 +12,7 @@ These presets are coded as higher order task functions. Each of these preset fun
 
 ```ts
 // just-task.js
+import { task } from 'just-task';
 import { tscTask } from 'just-task-preset';
 task('ts', tscTask());
 ```
@@ -20,6 +21,7 @@ Generally, these higher order functions also take an `options` argument to gener
 
 ```ts
 // just-task.js
+import { task } from 'just-task';
 import { tscTask } from 'just-task-preset';
 task('ts:commonjs', tscTask({ module: 'commonjs' }));
 task('ts:esnext', tscTask({ module: 'esnext' }));


### PR DESCRIPTION
This change-set adds missing imports in "Getting Started" documentation code snippets which tripped me up while on-boarding. @kenotron few questions regarding contributing:

1. Rush build currently fails on `just-task` even on `master`. Is this expected?
1. Should `npm run build:docs` have rebuilt the HTML? 

Thanks for this lib 👏! It is helping me resurrect an outdated gulp + TypeScript project.